### PR TITLE
Re-raise socket errors after retries are exhausted

### DIFF
--- a/lib/k8s/transport.rb
+++ b/lib/k8s/transport.rb
@@ -308,12 +308,14 @@ module K8s
       begin
         response = excon_client.request(**excon_options)
       rescue  Excon::Error::Socket => e
-        logger.warn { "Retrying request due to Excon::Error:Socket Error: #{e.message}" }
         if retries < MAX_RETRIES
-          sleep (BACKOFF_FACTOR ** retries)
           retries += 1
+          logger.warn { "#{format_request(options)} => Excon::Error::Socket: #{e.message} (retry #{retries}/#{MAX_RETRIES})" }
+          sleep (BACKOFF_FACTOR ** retries)
           retry
         end
+        logger.error { "#{format_request(options)} => Excon::Error::Socket: #{e.message} (exhausted #{MAX_RETRIES} retries)" }
+        raise
       end
 
       t = Time.now - start


### PR DESCRIPTION
## Summary
- When `Excon::Error::Socket` is raised and all 3 retries are exhausted, the rescue block falls through without re-raising
- `response` stays `nil`, then `parse_response(nil, ...)` calls `nil.headers` producing a misleading `NoMethodError: undefined method 'headers' for nil`
- Fix: add `raise` after the retry guard so callers see the actual socket error

## Context
Discovered via buildio/antimony#1197 — builds completing but deployments failing with `NoMethodError` that was misdiagnosed as stale K8s credentials.